### PR TITLE
Fix: roadmap and transformation sections for v2

### DIFF
--- a/src/components/home/roadmapsolving.tsx
+++ b/src/components/home/roadmapsolving.tsx
@@ -37,8 +37,8 @@ const RoadmapSolving: FC = () => {
           left: '50%',
           transform: 'translateX(-50%)',
           width: '4px',
-          height: '750px',
-          backgroundColor: 'orange',
+          height: '1050px',
+          background: 'linear-gradient(to bottom, transparent, #0066FF 40px, #0066FF)',
           zIndex: 1,
         }}
       />
@@ -53,7 +53,7 @@ const RoadmapSolving: FC = () => {
           height: 0,
           borderLeft: '10px solid transparent',
           borderRight: '10px solid transparent',
-          borderTop: '20px solid orange',
+          borderTop: '20px solid #0066FF',
           borderBottomLeftRadius: '-10px',
           borderBottomRightRadius: '-10px',
           zIndex: 1,
@@ -82,7 +82,7 @@ const RoadmapSolving: FC = () => {
                   width: '15px',
                   height: '15px',                
                   borderRadius: '50%',
-                  border: '4px solid orange',
+                  border: '4px solid #0066FF',
                   backgroundColor: 'white',
                   zIndex: 2,
                 }}
@@ -108,8 +108,10 @@ const RoadmapSolving: FC = () => {
                   right: index % 2 !== 0 ? 'calc(50% + 5px)' : 'auto',
                   width: '200px',
                   height: '2px',
-                  backgroundColor: 'orange',
-                  zIndex: 3,
+                  background: index % 2 === 0
+                  ? 'linear-gradient(to right, #0066FF 10%, transparent)'
+                  : 'linear-gradient(to left, #0066FF 10%, transparent)',
+                zIndex: 3,                  
                   margin: '0 auto',
                   }}
                 />

--- a/src/components/home/transformbusiness.tsx
+++ b/src/components/home/transformbusiness.tsx
@@ -25,12 +25,14 @@ const transformbusiness: FC = () => {
             variant="outlined"
             href="https://my.workee.net/consultant-metasurf-ai"
             sx={{
-              borderColor: '#8B0000',
-              color: '#8B0000',
+              borderColor: '#0066FF',
+              color: '#0066FF',
+              padding: '12px 24px',
+              fontSize: '1rem',
               width: 'fit-content',
               '&:hover': {
-                borderColor: '#8B0000',
-                backgroundColor: 'rgba(139, 0, 0, 0.04)'
+                borderColor: '#0066FF',
+                backgroundColor: 'rgba(0, 127, 139, 0.04)'
               }
             }}
           >


### PR DESCRIPTION
1. Fixed the vertical line in the roadmap section.
2. Changed color of the roadmap arrow to match the general theme.
3. Added fade effect to the arrow.
4. Made the transform business section button bigger.
5. Changed its color to match the general theme.